### PR TITLE
feature/fix calculate background

### DIFF
--- a/Data/ZeissImport/SampleMosaic/_meta.xml
+++ b/Data/ZeissImport/SampleMosaic/_meta.xml
@@ -18,7 +18,7 @@
       <V4/>
       <I4>1551</I4>
       <A4>0</A4>
-      <V5>05MAR09_run2_64-Raw.bmp</V5>
+      <V5>SampleMosaic.bmp</V5>
       <I5>1553</I5>
       <A5>0</A5>
       <V6/>

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -158,16 +158,16 @@ CalculateBackground::ArrayType CalculateBackground::getArrayType()
       setErrorCondition(-53000, msg);
       return ArrayType::Error;
     }
-    const std::type_info& daType = typeid(da.get());
-    if(typeid(UInt8ArrayType) == daType)
+    QString typeString = da->getTypeAsString();
+    if("uint8_t" == typeString)
     {
       return ArrayType::UInt8;
     }
-    if(typeid(UInt16ArrayType) == daType)
+    if("uint16_t" == typeString)
     {
       return ArrayType::UInt16;
     }
-    if(typeid(FloatArrayType) == daType)
+    if("float" == typeString)
     {
       return ArrayType::Float32;
     }

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -364,10 +364,10 @@ void CalculateBackground::calculateOutputValues(ArrayType arrayType, GeomType ge
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      calculateOutputValues<UInt8ArrayType, ImageGeom, UInt64ArrayType>();
+      calculateOutputValues<uint8_t, ImageGeom, uint64_t>();
       break;
     case GeomType::RectGridGeom:
-      calculateOutputValues<UInt8ArrayType, RectGridGeom, UInt64ArrayType>();
+      calculateOutputValues<uint8_t, RectGridGeom, uint64_t>();
       break;
     case GeomType::Error:
       break;
@@ -377,10 +377,10 @@ void CalculateBackground::calculateOutputValues(ArrayType arrayType, GeomType ge
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      calculateOutputValues<UInt16ArrayType, ImageGeom, UInt64ArrayType>();
+      calculateOutputValues<uint16_t, ImageGeom, uint64_t>();
       break;
     case GeomType::RectGridGeom:
-      calculateOutputValues<UInt16ArrayType, RectGridGeom, UInt64ArrayType>();
+      calculateOutputValues<uint16_t, RectGridGeom, uint64_t>();
       break;
     case GeomType::Error:
       break;
@@ -390,10 +390,10 @@ void CalculateBackground::calculateOutputValues(ArrayType arrayType, GeomType ge
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      calculateOutputValues<FloatArrayType, ImageGeom, DoubleArrayType>();
+      calculateOutputValues<float, ImageGeom, double>();
       break;
     case GeomType::RectGridGeom:
-      calculateOutputValues<FloatArrayType, RectGridGeom, DoubleArrayType>();
+      calculateOutputValues<float, RectGridGeom, double>();
       break;
     case GeomType::Error:
       break;

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -127,16 +127,6 @@ void CalculateBackground::setupFilterParameters()
   parameters.push_back(SIMPL_NEW_INTEGER_FP("Lowest allowed Image value (Image Value)", lowThresh, FilterParameter::Parameter, CalculateBackground));
   parameters.push_back(SIMPL_NEW_INTEGER_FP("Highest allowed Image value (Image Value)", highThresh, FilterParameter::Parameter, CalculateBackground));
 
-  {
-    QStringList linkedProps;
-    linkedProps.clear();
-    linkedProps << "SubtractBackground";
-    linkedProps << "DivideBackground";
-    parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Use Polynomial", Polynomial, FilterParameter::Parameter, CalculateBackground, linkedProps));
-    parameters.push_back(SIMPL_NEW_BOOL_FP("Subtract Background from Current Images", SubtractBackground, FilterParameter::Parameter, CalculateBackground));
-    parameters.push_back(SIMPL_NEW_BOOL_FP("Divide Background from Current Images", DivideBackground, FilterParameter::Parameter, CalculateBackground));
-  }
-
   // Only allow the Gaussian Blur property if the required filter is available
   FilterManager* filtManager = FilterManager::Instance();
   IFilterFactory::Pointer factory = filtManager->getFactoryFromClassName("ItkDiscreteGaussianBlur");
@@ -149,6 +139,9 @@ void CalculateBackground::setupFilterParameters()
     parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Use Gaussian Blur", GaussianBlur, FilterParameter::Parameter, CalculateBackground, linkedProps));
     parameters.push_back(SIMPL_NEW_FLOAT_FP("Gaussian: Std Deviations", GaussianStdVariation, FilterParameter::Parameter, CalculateBackground));
   }
+
+  parameters.push_back(SIMPL_NEW_BOOL_FP("Subtract Background from Current Images", SubtractBackground, FilterParameter::Parameter, CalculateBackground));
+  parameters.push_back(SIMPL_NEW_BOOL_FP("Divide Background from Current Images", DivideBackground, FilterParameter::Parameter, CalculateBackground));
 
   setFilterParameters(parameters);
 }

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -127,8 +127,15 @@ void CalculateBackground::setupFilterParameters()
   parameters.push_back(SIMPL_NEW_INTEGER_FP("Lowest allowed Image value (Image Value)", lowThresh, FilterParameter::Parameter, CalculateBackground));
   parameters.push_back(SIMPL_NEW_INTEGER_FP("Highest allowed Image value (Image Value)", highThresh, FilterParameter::Parameter, CalculateBackground));
 
-  parameters.push_back(SIMPL_NEW_BOOL_FP("Subtract Background from Current Images", SubtractBackground, FilterParameter::Parameter, CalculateBackground));
-  parameters.push_back(SIMPL_NEW_BOOL_FP("Divide Background from Current Images", DivideBackground, FilterParameter::Parameter, CalculateBackground));
+  {
+    QStringList linkedProps;
+    linkedProps.clear();
+    linkedProps << "SubtractBackground";
+    linkedProps << "DivideBackground";
+    parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Use Polynomial", Polynomial, FilterParameter::Parameter, CalculateBackground, linkedProps));
+    parameters.push_back(SIMPL_NEW_BOOL_FP("Subtract Background from Current Images", SubtractBackground, FilterParameter::Parameter, CalculateBackground));
+    parameters.push_back(SIMPL_NEW_BOOL_FP("Divide Background from Current Images", DivideBackground, FilterParameter::Parameter, CalculateBackground));
+  }
 
   // Only allow the Gaussian Blur property if the required filter is available
   FilterManager* filtManager = FilterManager::Instance();

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -452,7 +452,7 @@ const QString CalculateBackground::getFilterVersion() const
 // -----------------------------------------------------------------------------
 const QString CalculateBackground::getGroupName() const
 {
-  return SIMPL::FilterGroups::Unsupported;
+  return SIMPL::FilterGroups::ProcessingFilters;
 }
 
 // -----------------------------------------------------------------------------
@@ -476,7 +476,7 @@ const QUuid CalculateBackground::getUuid()
 // -----------------------------------------------------------------------------
 const QString CalculateBackground::getSubGroupName() const
 {
-  return "Misc";
+  return SIMPL::FilterSubGroups::MiscFilters;
 }
 
 // -----------------------------------------------------------------------------

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -250,7 +250,7 @@ void CalculateBackground::dataCheck()
   // CheckInputArrays() templated on array and geometry types.
   ArrayType arrayType = getArrayType();
   GeomType geomType = getGeomType();
-  IGeometryGrid::Pointer outputGridGeom = checkInputArrays(arrayType, geomType);
+  IGeometryGrid::Pointer outputGridGeom = checkInputArraysTemplate(arrayType, geomType);
 
   if(getErrorCode() < 0)
   {
@@ -316,7 +316,7 @@ void CalculateBackground::execute()
 
   ArrayType arrayType = getArrayType();
   GeomType geomType = getGeomType();
-  calculateOutputValues(arrayType, geomType);
+  calculateOutputValuesTemplate(arrayType, geomType);
 }
 
 // -----------------------------------------------------------------------------
@@ -330,9 +330,9 @@ IGeometryGrid::Pointer CalculateBackground::checkInputArrays(ArrayType arrayType
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      return checkInputArrays<UInt8ArrayType, ImageGeom>();
+      return checkInputArraysTemplate<UInt8ArrayType, ImageGeom>();
     case GeomType::RectGridGeom:
-      return checkInputArrays<UInt8ArrayType, RectGridGeom>();
+      return checkInputArraysTemplate<UInt8ArrayType, RectGridGeom>();
     default:
       setErrorCondition(-53005, "A valid geometry type (ImageGeom or RectGridGeom) is required for this filter.");
     }
@@ -341,9 +341,9 @@ IGeometryGrid::Pointer CalculateBackground::checkInputArrays(ArrayType arrayType
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      return checkInputArrays<UInt16ArrayType, ImageGeom>();
+      return checkInputArraysTemplate<UInt16ArrayType, ImageGeom>();
     case GeomType::RectGridGeom:
-      return checkInputArrays<UInt16ArrayType, RectGridGeom>();
+      return checkInputArraysTemplate<UInt16ArrayType, RectGridGeom>();
     default:
       setErrorCondition(-53005, "A valid geometry type (ImageGeom or RectGridGeom) is required for this filter.");
     }
@@ -352,9 +352,9 @@ IGeometryGrid::Pointer CalculateBackground::checkInputArrays(ArrayType arrayType
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      return checkInputArrays<FloatArrayType, ImageGeom>();
+      return checkInputArraysTemplate<FloatArrayType, ImageGeom>();
     case GeomType::RectGridGeom:
-      return checkInputArrays<FloatArrayType, RectGridGeom>();
+      return checkInputArraysTemplate<FloatArrayType, RectGridGeom>();
     default:
       setErrorCondition(-53005, "A valid geometry type (ImageGeom or RectGridGeom) is required for this filter.");
     }
@@ -377,10 +377,10 @@ void CalculateBackground::calculateOutputValues(ArrayType arrayType, GeomType ge
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      calculateOutputValues<uint8_t, ImageGeom, uint64_t>();
+      calculateOutputValuesTemplate<uint8_t, ImageGeom, uint64_t>();
       break;
     case GeomType::RectGridGeom:
-      calculateOutputValues<uint8_t, RectGridGeom, uint64_t>();
+      calculateOutputValuesTemplate<uint8_t, RectGridGeom, uint64_t>();
       break;
     case GeomType::Error:
       break;
@@ -390,10 +390,10 @@ void CalculateBackground::calculateOutputValues(ArrayType arrayType, GeomType ge
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      calculateOutputValues<uint16_t, ImageGeom, uint64_t>();
+      calculateOutputValuesTemplate<uint16_t, ImageGeom, uint64_t>();
       break;
     case GeomType::RectGridGeom:
-      calculateOutputValues<uint16_t, RectGridGeom, uint64_t>();
+      calculateOutputValuesTemplate<uint16_t, RectGridGeom, uint64_t>();
       break;
     case GeomType::Error:
       break;
@@ -403,10 +403,10 @@ void CalculateBackground::calculateOutputValues(ArrayType arrayType, GeomType ge
     switch(geomType)
     {
     case GeomType::ImageGeom:
-      calculateOutputValues<float, ImageGeom, double>();
+      calculateOutputValuesTemplate<float, ImageGeom, double>();
       break;
     case GeomType::RectGridGeom:
-      calculateOutputValues<float, RectGridGeom, double>();
+      calculateOutputValuesTemplate<float, RectGridGeom, double>();
       break;
     case GeomType::Error:
       break;

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -250,7 +250,7 @@ void CalculateBackground::dataCheck()
   // CheckInputArrays() templated on array and geometry types.
   ArrayType arrayType = getArrayType();
   GeomType geomType = getGeomType();
-  IGeometryGrid::Pointer outputGridGeom = checkInputArraysTemplate(arrayType, geomType);
+  IGeometryGrid::Pointer outputGridGeom = checkInputArrays(arrayType, geomType);
 
   if(getErrorCode() < 0)
   {
@@ -316,7 +316,7 @@ void CalculateBackground::execute()
 
   ArrayType arrayType = getArrayType();
   GeomType geomType = getGeomType();
-  calculateOutputValuesTemplate(arrayType, geomType);
+  calculateOutputValues(arrayType, geomType);
 }
 
 // -----------------------------------------------------------------------------

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -48,7 +48,9 @@
 #include "SIMPLib/FilterParameters/BooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/DataArrayCreationFilterParameter.h"
 #include "SIMPLib/FilterParameters/DataContainerCreationFilterParameter.h"
+#include "SIMPLib/FilterParameters/FloatFilterParameter.h"
 #include "SIMPLib/FilterParameters/IntFilterParameter.h"
+#include "SIMPLib/FilterParameters/LinkedBooleanFilterParameter.h"
 #include "SIMPLib/FilterParameters/MultiDataContainerSelectionFilterParameter.h"
 #include "SIMPLib/FilterParameters/SeparatorFilterParameter.h"
 #include "SIMPLib/FilterParameters/StringFilterParameter.h"
@@ -87,6 +89,7 @@ CalculateBackground::CalculateBackground()
 , m_highThresh(255)
 , m_SubtractBackground(false)
 , m_DivideBackground(false)
+, m_GaussianStdVariation(2)
 {
 }
 
@@ -126,6 +129,19 @@ void CalculateBackground::setupFilterParameters()
 
   parameters.push_back(SIMPL_NEW_BOOL_FP("Subtract Background from Current Images", SubtractBackground, FilterParameter::Parameter, CalculateBackground));
   parameters.push_back(SIMPL_NEW_BOOL_FP("Divide Background from Current Images", DivideBackground, FilterParameter::Parameter, CalculateBackground));
+
+  // Only allow the Gaussian Blur property if the required filter is available
+  FilterManager* filtManager = FilterManager::Instance();
+  IFilterFactory::Pointer factory = filtManager->getFactoryFromClassName("ItkDiscreteGaussianBlur");
+  if(nullptr != factory.get())
+  {
+    QStringList linkedProps;
+    linkedProps.clear();
+    linkedProps << "GaussianStdVariation";
+
+    parameters.push_back(SIMPL_NEW_LINKED_BOOL_FP("Use Gaussian Blur", GaussianBlur, FilterParameter::Parameter, CalculateBackground, linkedProps));
+    parameters.push_back(SIMPL_NEW_FLOAT_FP("Gaussian: Std Deviations", GaussianStdVariation, FilterParameter::Parameter, CalculateBackground));
+  }
 
   setFilterParameters(parameters);
 }

--- a/ZeissImportFilters/CalculateBackground.cpp
+++ b/ZeissImportFilters/CalculateBackground.cpp
@@ -305,9 +305,6 @@ void CalculateBackground::preflight()
 // -----------------------------------------------------------------------------
 void CalculateBackground::execute()
 {
-  int err = 0;
-  int xval = 0;
-  int yval = 0;
   // typically run your dataCheck function to make sure you can get that far and all your variables are initialized
   dataCheck();
   // Check to make sure you made it through the data check. Errors would have been reported already so if something

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -264,6 +264,17 @@ protected:
   template<typename DataArrayType, typename GeometryType>
   std::shared_ptr<GeometryType> checkInputArraysTemplate()
   {
+    if(typeid(GeometryType) != typeid(ImageGeom) && typeid(GeometryType) != typeid(RectGridGeom))
+    {
+      setErrorCondition(-53011, "Invalid geometry type");
+      return;
+    }
+    if(typeid(OutArrayType) != typeid(UInt8ArrayType) && typeid(OutArrayType) != typeid(UInt16ArrayType) && typeid(OutArrayType) != typeid(FloatArrayType))
+    {
+      setErrorCondition(-53012, "Invalid array type");
+      return;
+    }
+
     DataContainerArray::Pointer dca = getDataContainerArray();
     QVector<size_t> cDims = { 1 };
     typename GeometryType::Pointer outputGridGeom = GeometryType::NullPointer();
@@ -309,6 +320,17 @@ protected:
   template<typename OutArrayType, typename GeomType, typename AccumType>
   void calculateOutputValuesTemplate()
   {
+    if(typeid(GeomType) != typeid(ImageGeom) && typeid(GeomType) != typeid(RectGridGeom))
+    {
+      setErrorCondition(-53011, "Invalid geometry type");
+      return;
+    }
+    if(typeid(OutArrayType) != typeid(uint8_t) && typeid(OutArrayType) != typeid(uint16_t) && typeid(OutArrayType) != typeid(float))
+    {
+      setErrorCondition(-53012, "Invalid array type");
+      return;
+    }
+
     DataContainerArray::Pointer dca = getDataContainerArray();
 
     DataContainer::Pointer outputDc = dca->getDataContainer(getOutputDataContainerPath());

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -324,7 +324,7 @@ protected:
       {
         if(imageArray[t] >= m_lowThresh && imageArray[t] <= m_highThresh)
         {
-          accumArray[t] += imageArray[t];
+          accumArray[t] = accumArray[t] + imageArray[t];
           counter[t]++;
         }
       }
@@ -333,12 +333,12 @@ protected:
     // average the background values by the number of counts (counts will be the number of images unless the threshold
     // values do not include all the possible image values
     // (i.e. for an 8 bit image, if we only include values from 0 to 100, not every image value will be counted)
-    for(size_t j = 0; j < numTuples; j++)
+    for(int j = 0; j < numTuples; j++)
     {
-      accumArray[j] /= counter[j];
+      accumArray[j] = accumArray[j] /= counter[j];
     }
 
-    for(size_t i = 0; i < numTuples; ++i)
+    for(int i = 0; i < numTuples; ++i)
     {
       outputArray[i] = static_cast<uint8_t>(accumArray[i]);
     }

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -53,13 +53,14 @@ class ZeissImport_EXPORT CalculateBackground : public AbstractFilter
 {
   Q_OBJECT
   PYB11_CREATE_BINDINGS(CalculateBackground SUPERCLASS AbstractFilter)
-  PYB11_PROPERTY(DataArrayPath VolumeDataContainerName READ getVolumeDataContainerName WRITE setVolumeDataContainerName)
-  PYB11_PROPERTY(QString BackgroundAttributeMatrixName READ getBackgroundAttributeMatrixName WRITE setBackgroundAttributeMatrixName)
+  PYB11_PROPERTY(QStringList DataContainers READ getDataContainers WRITE setDataContainers)
   PYB11_PROPERTY(QString CellAttributeMatrixName READ getCellAttributeMatrixName WRITE setCellAttributeMatrixName)
-  PYB11_PROPERTY(DataArrayPath ImageDataArrayPath READ getImageDataArrayPath WRITE setImageDataArrayPath)
-  PYB11_PROPERTY(DataArrayPath AttributeMatrixName READ getAttributeMatrixName WRITE setAttributeMatrixName)
-  PYB11_PROPERTY(DataArrayPath DataContainerBundleName READ getDataContainerBundleName WRITE setDataContainerBundleName)
-  PYB11_PROPERTY(QString BackgroundImageArrayName READ getBackgroundImageArrayName WRITE setBackgroundImageArrayName)
+  PYB11_PROPERTY(DataArrayPath ImageDataArrayName READ getImageDataArrayName WRITE setImageDataArrayName)
+
+  PYB11_PROPERTY(DataArrayPath OutputDataContainerPath READ getOutputDataContainerPath WRITE setOutputDataContainerPath)
+  PYB11_PROPERTY(DataArrayPath OutputCellAttributeMatrixPath READ getOutputCellAttributeMatrixPath WRITE setOutputCellAttributeMatrixPath)
+  PYB11_PROPERTY(DataArrayPath OutputImageArrayPath READ getOutputImageArrayPath WRITE setOutputImageArrayPath)
+
   PYB11_PROPERTY(uint lowThresh READ getlowThresh WRITE setlowThresh)
   PYB11_PROPERTY(uint highThresh READ gethighThresh WRITE sethighThresh)
   PYB11_PROPERTY(bool SubtractBackground READ getSubtractBackground WRITE setSubtractBackground)
@@ -74,26 +75,23 @@ public:
 
   SIMPL_INSTANCE_STRING_PROPERTY(DataContainerName)
 
-  SIMPL_FILTER_PARAMETER(DataArrayPath, VolumeDataContainerName)
-  Q_PROPERTY(DataArrayPath VolumeDataContainerName READ getVolumeDataContainerName WRITE setVolumeDataContainerName)
-
-  SIMPL_FILTER_PARAMETER(QString, BackgroundAttributeMatrixName)
-  Q_PROPERTY(QString BackgroundAttributeMatrixName READ getBackgroundAttributeMatrixName WRITE setBackgroundAttributeMatrixName)
+  SIMPL_FILTER_PARAMETER(QStringList, DataContainers)
+  Q_PROPERTY(QStringList DataContainers READ getDataContainers WRITE setDataContainers)
 
   SIMPL_FILTER_PARAMETER(QString, CellAttributeMatrixName)
   Q_PROPERTY(QString CellAttributeMatrixName READ getCellAttributeMatrixName WRITE setCellAttributeMatrixName)
 
-  SIMPL_FILTER_PARAMETER(DataArrayPath, ImageDataArrayPath)
-  Q_PROPERTY(DataArrayPath ImageDataArrayPath READ getImageDataArrayPath WRITE setImageDataArrayPath)
+  SIMPL_FILTER_PARAMETER(QString, ImageDataArrayName)
+  Q_PROPERTY(QString ImageDataArrayName READ getImageDataArrayName WRITE setImageDataArrayName)
 
-  SIMPL_FILTER_PARAMETER(DataArrayPath, AttributeMatrixName)
-  Q_PROPERTY(DataArrayPath AttributeMatrixName READ getAttributeMatrixName WRITE setAttributeMatrixName)
+  SIMPL_FILTER_PARAMETER(DataArrayPath, OutputDataContainerPath)
+  Q_PROPERTY(DataArrayPath OutputDataContainerPath READ getOutputDataContainerPath WRITE setOutputDataContainerPath)
 
-  SIMPL_FILTER_PARAMETER(DataArrayPath, DataContainerBundleName)
-  Q_PROPERTY(DataArrayPath DataContainerBundleName READ getDataContainerBundleName WRITE setDataContainerBundleName)
+  SIMPL_FILTER_PARAMETER(DataArrayPath, OutputCellAttributeMatrixPath)
+  Q_PROPERTY(DataArrayPath OutputCellAttributeMatrixPath READ getOutputCellAttributeMatrixPath WRITE setOutputCellAttributeMatrixPath)
 
-  SIMPL_FILTER_PARAMETER(QString, BackgroundImageArrayName)
-  Q_PROPERTY(QString BackgroundImageArrayName READ getBackgroundImageArrayName WRITE setBackgroundImageArrayName)
+  SIMPL_FILTER_PARAMETER(DataArrayPath, OutputImageArrayPath)
+  Q_PROPERTY(DataArrayPath OutputImageArrayPath READ getOutputImageArrayPath WRITE setOutputImageArrayPath)
 
   SIMPL_FILTER_PARAMETER(uint, lowThresh)
   Q_PROPERTY(uint lowThresh READ getlowThresh WRITE setlowThresh)
@@ -158,11 +156,6 @@ public:
   void setupFilterParameters() override;
 
   /**
-   * @brief readFilterParameters Reimplemented from @see AbstractFilter class
-   */
-  void readFilterParameters(AbstractFilterParametersReader* reader, int index) override;
-
-  /**
    * @brief execute Reimplemented from @see AbstractFilter class
    */
   void execute() override;
@@ -209,9 +202,9 @@ protected:
   void initialize();
 
 private:
-  int64_t m_TotalPoints;
+  //  int64_t m_TotalPoints;
 
-  DEFINE_DATAARRAY_VARIABLE(double, BackgroundImage)
+  //  DEFINE_DATAARRAY_VARIABLE(double, BackgroundImage)
 
 public:
   CalculateBackground(const CalculateBackground&) = delete;            // Copy Constructor Not Implemented

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -376,7 +376,8 @@ protected:
     // (i.e. for an 8 bit image, if we only include values from 0 to 100, not every image value will be counted)
     for(int j = 0; j < numTuples; j++)
     {
-      accumArray[j] /= counter[j];
+      // Avoid dividing by 0 when counter[j] == 0
+      accumArray[j] = (counter[j] == 0) ?  0 : accumArray[j] / counter[j];
     }
 
 #if 0
@@ -505,7 +506,10 @@ protected:
           {
             if((image[t] >= m_lowThresh) && (image[t] <= m_highThresh))
             {
-              image[t] /= outputArray[t];
+              if(outputArray[t] != 0)
+              {
+                image[t] /= outputArray[t];
+              }
             }
           }
         }

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -266,13 +266,13 @@ protected:
   {
     DataContainerArray::Pointer dca = getDataContainerArray();
     QVector<size_t> cDims = { 1 };
-    GeometryType::Pointer outputGridGeom = GeometryType::NullPointer();
+    typename GeometryType::Pointer outputGridGeom = GeometryType::NullPointer();
 
     // Ensure each DataContainer has the proper path to the image data and the image data is grayscale
     for(const auto& dcName : m_DataContainers)
     {
       DataArrayPath imageArrayPath(dcName, m_CellAttributeMatrixName, m_ImageDataArrayName);
-      DataArrayType::Pointer imageData = dca->getPrereqArrayFromPath<DataArrayType, AbstractFilter>(this, imageArrayPath, cDims);
+      typename DataArrayType::Pointer imageData = dca->getPrereqArrayFromPath<DataArrayType, AbstractFilter>(this, imageArrayPath, cDims);
       if(imageData.get() == nullptr)
       {
         QString msg;
@@ -283,7 +283,7 @@ protected:
 
       if(getErrorCode() >= 0)
       {
-        GeometryType::Pointer gridGeom = dca->getDataContainer(dcName)->getGeometryAs<GeometryType>();
+        typename GeometryType::Pointer gridGeom = dca->getDataContainer(dcName)->getGeometryAs<GeometryType>();
         if(gridGeom.get() != nullptr)
         {
           if(outputGridGeom.get() == nullptr)
@@ -313,16 +313,16 @@ protected:
 
     DataContainer::Pointer outputDc = dca->getDataContainer(getOutputDataContainerPath());
     AttributeMatrix::Pointer outputAttrMat = outputDc->getAttributeMatrix(getOutputCellAttributeMatrixPath());
-    DataArray<OutArrayType>::Pointer outputArrayPtr = outputAttrMat->getAttributeArrayAs<DataArray<OutArrayType>>(m_OutputImageArrayPath.getDataArrayName());
-    DataArray<OutArrayType>& outputArray = *(outputArrayPtr);
+    typename DataArray<OutArrayType>::Pointer outputArrayPtr = outputAttrMat->getAttributeArrayAs<DataArray<OutArrayType>>(m_OutputImageArrayPath.getDataArrayName());
+    typename DataArray<OutArrayType>& outputArray = *(outputArrayPtr);
 
-    GeomType::Pointer outputGeom = outputDc->getGeometryAs<GeomType>();
+    typename GeomType::Pointer outputGeom = outputDc->getGeometryAs<GeomType>();
     SizeVec3Type dims;
     outputGeom->getDimensions(dims);
 
-    DataArray<AccumType>::Pointer accumulateArrayPtr = DataArray<AccumType>::CreateArray(outputArrayPtr->getNumberOfTuples(), "Accumulation Array", true);
+    typename DataArray<AccumType>::Pointer accumulateArrayPtr = typename DataArray<AccumType>::CreateArray(outputArrayPtr->getNumberOfTuples(), "Accumulation Array", true);
     accumulateArrayPtr->initializeWithZeros();
-    DataArray<AccumType>& accumArray = *accumulateArrayPtr;
+    typename DataArray<AccumType>& accumArray = *accumulateArrayPtr;
     size_t numTuples = accumArray.getNumberOfTuples();
 
     SizeTArrayType::Pointer countArrayPtr = SizeTArrayType::CreateArray(outputArrayPtr->getNumberOfTuples(), "Count Array", true);
@@ -331,7 +331,7 @@ protected:
     for(const auto& dcName : m_DataContainers)
     {
       DataArrayPath imageArrayPath(dcName, m_CellAttributeMatrixName, m_ImageDataArrayName);
-      DataArray<OutArrayType>& imageArray = *(dca->getAttributeMatrix(imageArrayPath)->getAttributeArrayAs<DataArray<OutArrayType>>(imageArrayPath.getDataArrayName()));
+      typename DataArray<OutArrayType>& imageArray = *(dca->getAttributeMatrix(imageArrayPath)->getAttributeArrayAs<DataArray<OutArrayType>>(imageArrayPath.getDataArrayName()));
 
       for(size_t t = 0; t < numTuples; t++)
       {
@@ -445,7 +445,7 @@ protected:
         size_t totalPoints = imagePtr->getNumberOfComponents();
         if(nullptr != imagePtr.get())
         {
-          auto* image = imagePtr->getPointer(0);
+          typename auto* image = imagePtr->getPointer(0);
 
           for(size_t t = 0; t < totalPoints; t++)
           {
@@ -471,7 +471,7 @@ protected:
         size_t totalPoints = imagePtr->getNumberOfComponents();
         if(nullptr != imagePtr.get())
         {
-          auto* image = imagePtr->getPointer(0);
+          typename auto* image = imagePtr->getPointer(0);
 
           for(size_t t = 0; t < totalPoints; t++)
           {

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -324,7 +324,7 @@ protected:
       {
         if(imageArray[t] >= m_lowThresh && imageArray[t] <= m_highThresh)
         {
-          accumArray[t] = accumArray[t] + imageArray[t];
+          accumArray[t] += imageArray[t];
           counter[t]++;
         }
       }
@@ -335,7 +335,7 @@ protected:
     // (i.e. for an 8 bit image, if we only include values from 0 to 100, not every image value will be counted)
     for(int j = 0; j < numTuples; j++)
     {
-      accumArray[j] = accumArray[j] /= counter[j];
+      accumArray[j] /= counter[j];
     }
 
 #if 0

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -36,6 +36,8 @@
 
 #include "SIMPLib/Common/SIMPLibSetGetMacros.h"
 #include "SIMPLib/Filtering/AbstractFilter.h"
+#include "SIMPLib/Filtering/FilterManager.h"
+#include "SIMPLib/Filtering/IFilterFactory.hpp"
 #include "SIMPLib/Geometry/IGeometryGrid.h"
 #include "SIMPLib/SIMPLib.h"
 

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -262,7 +262,7 @@ protected:
    * @return
    */
   template<typename DataArrayType, typename GeometryType>
-  std::shared_ptr<GeometryType> checkInputArrays()
+  std::shared_ptr<GeometryType> checkInputArraysTemplate()
   {
     DataContainerArray::Pointer dca = getDataContainerArray();
     QVector<size_t> cDims = { 1 };
@@ -307,7 +307,7 @@ protected:
    * @brief Calculates the output values using the templated output IDataArray output type
    */
   template<typename OutArrayType, typename GeomType, typename AccumType>
-  void calculateOutputValues()
+  void calculateOutputValuesTemplate()
   {
     DataContainerArray::Pointer dca = getDataContainerArray();
 

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -313,6 +313,12 @@ protected:
 
     DataContainer::Pointer outputDc = dca->getDataContainer(getOutputDataContainerPath());
     AttributeMatrix::Pointer outputAttrMat = outputDc->getAttributeMatrix(getOutputCellAttributeMatrixPath());
+    if(nullptr == outputAttrMat)
+    {
+      setErrorCondition(-53010, "Output AttributeMatrix does not exist");
+      return;
+    }
+
     typename DataArray<OutArrayType>::Pointer outputArrayPtr = outputAttrMat->getAttributeArrayAs<DataArray<OutArrayType>>(m_OutputImageArrayPath.getDataArrayName());
     typename DataArray<OutArrayType>& outputArray = *(outputArrayPtr);
 

--- a/ZeissImportFilters/CalculateBackground.h
+++ b/ZeissImportFilters/CalculateBackground.h
@@ -264,7 +264,7 @@ protected:
       {
         QString msg;
         QTextStream out(&msg);
-        out << "Attribute Array Path: " << imageArrayPath.serialize() << " is not UInt8{1} (Grayscale) data. Please select a pattern of AttributeArray Paths that are gray scale images";
+        out << "Attribute Array Path: " << imageArrayPath.serialize() << " is not of the appropriate type and components{1} (Grayscale) data. Please select a pattern of AttributeArray Paths that are gray scale images";
         setErrorCondition(-53000, msg);
       }
 
@@ -300,16 +300,16 @@ protected:
 
     DataContainer::Pointer outputDc = dca->getDataContainer(getOutputDataContainerPath());
     AttributeMatrix::Pointer outputAttrMat = outputDc->getAttributeMatrix(getOutputCellAttributeMatrixPath());
-    OutArrayType::Pointer outputArrayPtr = outputAttrMat->getAttributeArrayAs<OutArrayType>(m_OutputImageArrayPath.getDataArrayName());
-    OutArrayType& outputArray = *(outputArrayPtr);
+    DataArray<OutArrayType>::Pointer outputArrayPtr = outputAttrMat->getAttributeArrayAs<DataArray<OutArrayType>>(m_OutputImageArrayPath.getDataArrayName());
+    DataArray<OutArrayType>& outputArray = *(outputArrayPtr);
 
     GeomType::Pointer outputGeom = outputDc->getGeometryAs<GeomType>();
     SizeVec3Type dims;
     outputGeom->getDimensions(dims);
 
-    AccumType::Pointer accumulateArrayPtr = AccumType::CreateArray(outputArrayPtr->getNumberOfTuples(), "Accumulation Array", true);
+    DataArray<AccumType>::Pointer accumulateArrayPtr = DataArray<AccumType>::CreateArray(outputArrayPtr->getNumberOfTuples(), "Accumulation Array", true);
     accumulateArrayPtr->initializeWithZeros();
-    AccumType& accumArray = *accumulateArrayPtr;
+    DataArray<AccumType>& accumArray = *accumulateArrayPtr;
     size_t numTuples = accumArray.getNumberOfTuples();
 
     SizeTArrayType::Pointer countArrayPtr = SizeTArrayType::CreateArray(outputArrayPtr->getNumberOfTuples(), "Count Array", true);
@@ -318,7 +318,7 @@ protected:
     for(const auto& dcName : m_DataContainers)
     {
       DataArrayPath imageArrayPath(dcName, m_CellAttributeMatrixName, m_ImageDataArrayName);
-      OutArrayType& imageArray = *(dca->getAttributeMatrix(imageArrayPath)->getAttributeArrayAs<OutArrayType>(imageArrayPath.getDataArrayName()));
+      DataArray<OutArrayType>& imageArray = *(dca->getAttributeMatrix(imageArrayPath)->getAttributeArrayAs<DataArray<OutArrayType>>(imageArrayPath.getDataArrayName()));
 
       for(size_t t = 0; t < numTuples; t++)
       {
@@ -387,7 +387,7 @@ protected:
 
     for(int i = 0; i < numTuples; ++i)
     {
-      outputArray[i] = static_cast<uint8_t>(accumArray[i]);
+      outputArray[i] = static_cast<OutArrayType>(accumArray[i]);
     }
 
 #if 0
@@ -403,7 +403,7 @@ protected:
         {
           auto* image = imagePtr->getPointer(0);
 
-          for(int64_t t = 0; t < totalPoints; t++)
+          for(size_t t = 0; t < totalPoints; t++)
           {
             if((image[t] >= m_lowThresh) && (image[t] <= m_highThresh))
             {

--- a/ZeissImportFilters/ImportAxioVisionV4Montage.cpp
+++ b/ZeissImportFilters/ImportAxioVisionV4Montage.cpp
@@ -68,10 +68,6 @@ static const QString k_TileAttributeMatrixDefaultName("Tile Data");
 static const QString k_GrayScaleTempArrayName("gray_scale_temp");
 static const QString k_AxioVisionMetaData("AxioVision MetaData");
 
-enum createdPathID : RenameDataPath::DataID_t
-{
-  DataContainerID = 1
-};
 
 /* ############## Start Private Implementation ############################### */
 // -----------------------------------------------------------------------------
@@ -475,7 +471,7 @@ void ImportAxioVisionV4Montage::parseImages(QDomElement& root, const ZeissTagsXm
     dcNameStream << colIndex;
 
     // Create the DataContainer with a name based on the ROW & COLUMN indices
-    DataContainer::Pointer dc = dca->createNonPrereqDataContainer<AbstractFilter>(this, dcName, DataContainerID);
+    DataContainer::Pointer dc = dca->createNonPrereqDataContainer<AbstractFilter>(this, dcName);
 
     // Create the Image Geometry
     ImageGeom::Pointer image = initializeImageGeom(root, photoTagsSection);


### PR DESCRIPTION
* Added Gaussian blur option and degree.  Gaussian blur options require the ItkDiscreteGaussianBlur filter, and if it is not found, the corresponding FilterParameters are not added to the CalculateBackground filter or the option available during execute().
* Enabled SubtractBackground and DivideBackground operations and moved them after the Gaussian blur.
* Fixed the calculation for the background image.